### PR TITLE
fix stringifyVersion

### DIFF
--- a/scripts/version-utils.ts
+++ b/scripts/version-utils.ts
@@ -22,7 +22,7 @@ export function stringifyPrerelease({ tagName, baseVersion, prepatch }: Prerelea
 
 export function stringifyVersion({ prerelease, ...mainVersion }: Version): string {
     const _mainVersion = stringifyMainVersion(mainVersion);
-    return prerelease ? `${_mainVersion}.${stringifyPrerelease(prerelease)}` : _mainVersion;
+    return prerelease ? `${_mainVersion}-${stringifyPrerelease(prerelease)}` : _mainVersion;
 }
 
 export function stringifyMainVersion({ major, minor, patch }: MainVersion): string {


### PR DESCRIPTION
prerelease を含むバージョン名の生成で間違ったバージョン名が生成される不具合を修正します。

- 誤: X.Y.Z.prerelease
- 正: X.Y.Z-prerelease