### PR TITLE
feat(index): flatted のライセンス情報を追加

### DIFF
--- a/wwawing.com/index.html
+++ b/wwawing.com/index.html
@@ -289,6 +289,8 @@
               href="https://github.com/brix/crypto-js/blob/develop/LICENSE">ライセンス情報</a>)</li>
           <li><a href="https://github.com/acornjs/acorn">acorn</a>(<a
               href="https://github.com/acornjs/acorn/blob/master/acorn/LICENSE">ライセンス情報</a>) (不安定版のみ)</li>
+           <li><a href="https://github.com/WebReflection/flatted">flatted</a>(<a
+              href="https://github.com/WebReflection/flatted/blob/main/LICENSE">ライセンス情報</a>) (不安定版のみ)</li>
         </ul>
         <h3>WWA Wing ができるまで / エイプリルフール</h3>
         <p><a href="http://old-experiments.wwawing.com/">WWA Wing ができるまで / エイプリルフール</a></p>


### PR DESCRIPTION
超不安定版のセーブバグが不安定版に入るに伴い、flatted 依存が増えるため、ライセンス情報に追記します。